### PR TITLE
Add sender overrides for secondary SMTP

### DIFF
--- a/DualSmtpBundle/Config/config.php
+++ b/DualSmtpBundle/Config/config.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+    'services' => [
+        'events' => [
+            'mautic.dual_smtp.email_subscriber' => [
+                'class' => \MauticPlugin\DualSmtpBundle\EventListener\EmailSubscriber::class,
+                'arguments' => [
+                    '%dual_smtp.dsn_2%',
+                    '%dual_smtp.mailer_from_email%',
+                    '%dual_smtp.mailer_reply_to_email%',
+                    '%dual_smtp.mailer_return_path%'
+                ]
+            ],
+        ],
+        'parameters' => [
+            'dual_smtp.dsn_2' => 'smtp://smtp2.example.com',
+            'dual_smtp.mailer_from_email' => 'info@crm.datainnovation.io',
+            'dual_smtp.mailer_reply_to_email' => 'info@datainnovation.io',
+            'dual_smtp.mailer_return_path' => 'info@crm.datainnovation.io',
+        ],
+    ],
+];

--- a/DualSmtpBundle/EventListener/EmailSubscriber.php
+++ b/DualSmtpBundle/EventListener/EmailSubscriber.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace MauticPlugin\DualSmtpBundle\EventListener;
+
+use Mautic\EmailBundle\EmailEvents;
+use Mautic\EmailBundle\Event\EmailSendEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Mailer\Transport;
+
+/**
+ * Switches the mail transport based on a contact's custom field named `smtp`.
+ * If the field value is "2" then the custom transport DSN is used. Any other
+ * value leaves the default transport untouched.
+ */
+class EmailSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private string $dsn2,
+        private string $fromEmail,
+        private string $replyToEmail,
+        private string $returnPath
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            EmailEvents::EMAIL_ON_SEND => ['onEmailSend', 0],
+        ];
+    }
+
+    public function onEmailSend(EmailSendEvent $event): void
+    {
+        $lead = $event->getLead();
+        if (empty($lead)) {
+            return;
+        }
+
+        $smtpValue = null;
+        if (is_array($lead)) {
+            $smtpValue = $lead['smtp'] ?? null;
+        } elseif (method_exists($lead, 'getFieldValue')) {
+            $smtpValue = $lead->getFieldValue('smtp');
+        }
+
+        if ('2' !== (string) $smtpValue) {
+            return;
+        }
+
+        $transport = Transport::fromDsn($this->dsn2);
+
+        $helper = $event->getHelper();
+        if (null === $helper) {
+            return;
+        }
+
+        // Overwrite the MailHelper's transport through reflection
+        $refClass = new \ReflectionClass($helper);
+        if ($refClass->hasProperty('transport')) {
+            $property = $refClass->getProperty('transport');
+            $property->setAccessible(true);
+            $property->setValue($helper, $transport);
+        }
+
+        // Update sender details for the secondary SMTP
+        $helper->setFrom($this->fromEmail);
+        $helper->setReplyTo($this->replyToEmail);
+        $helper->setReturnPath($this->returnPath);
+    }
+}

--- a/DualSmtpBundle/composer.json
+++ b/DualSmtpBundle/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "acme/mautic-dual-smtp-bundle",
+    "description": "Mautic plugin to select SMTP server based on contact field",
+    "type": "mautic-plugin",
+    "require": {},
+    "autoload": {
+        "psr-4": {
+            "MauticPlugin\\DualSmtpBundle\\": ""
+        }
+    }
+}

--- a/DualSmtpBundle/plugin.json
+++ b/DualSmtpBundle/plugin.json
@@ -1,0 +1,25 @@
+{
+    "name": "DualSmtpBundle",
+    "description": "Select SMTP server based on contact field",
+    "version": "1.0.0",
+    "author": "Acme",
+    "services": {
+        "events": {
+            "mautic.dual_smtp.email_subscriber": {
+                "class": "MauticPlugin\\DualSmtpBundle\\EventListener\\EmailSubscriber",
+                "arguments": [
+                    "%dual_smtp.dsn_2%",
+                    "%dual_smtp.mailer_from_email%",
+                    "%dual_smtp.mailer_reply_to_email%",
+                    "%dual_smtp.mailer_return_path%"
+                ]
+            }
+        },
+        "parameters": {
+            "dual_smtp.dsn_2": "smtp://smtp2.example.com",
+            "dual_smtp.mailer_from_email": "info@crm.datainnovation.io",
+            "dual_smtp.mailer_reply_to_email": "info@datainnovation.io",
+            "dual_smtp.mailer_return_path": "info@crm.datainnovation.io"
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# Mautic_Dual_SMTP
+# Dual SMTP Bundle
+
+This repository contains a Mautic plugin that switches to a secondary SMTP
+server and sender details based on the value of a contact's custom field
+`smtp`.
+
+When an email is sent, the plugin inspects the contact's `smtp` field:
+
+- Value `2` switches the transport to the custom SMTP DSN configured for the
+  plugin and rewrites the sender address, reply-to, and return-path.
+- Any other value, including `1`, leaves the default SMTP settings in place.
+
+The secondary DSN and sender addresses can be configured in
+`Config/config.php` or overridden through environment parameters.
+
+## Installation
+
+1. Copy the `DualSmtpBundle` directory to your Mautic installation's `plugins/` folder.
+2. Clear the cache with `php bin/console cache:clear`.
+3. Add a contact custom field named `smtp` with values `1` or `2`.
+
+## Usage
+
+Creating or updating a contact's `smtp` custom field will determine which SMTP server is used when emails are sent to that contact.


### PR DESCRIPTION
## Summary
- accept secondary DSN plus custom from, reply-to, and return-path parameters
- rewrite sender details and switch to secondary transport when contact's `smtp` field equals 2

## Testing
- `php -l DualSmtpBundle/EventListener/EmailSubscriber.php`
- `php -l DualSmtpBundle/Config/config.php`
- `jq . DualSmtpBundle/plugin.json >/dev/null`


------
https://chatgpt.com/codex/tasks/task_e_689daec12768832ca21788ecf14217c1